### PR TITLE
switch to normal print statements

### DIFF
--- a/src/commands/defensestate.py
+++ b/src/commands/defensestate.py
@@ -1,5 +1,4 @@
 from commands2.command import Command
-from wpilib import DataLogManager
 
 from subsystems.drive.drivesubsystem import DriveSubsystem
 
@@ -13,7 +12,7 @@ class DefenseState(Command):
         self.addRequirements(self.drive)
 
     def initialize(self) -> None:
-        DataLogManager.log(f"Command: {self.getName()}")
+        print(f"Command: {self.getName()}")
 
     def execute(self) -> None:
         self.drive.defenseState()
@@ -22,4 +21,4 @@ class DefenseState(Command):
         return True
 
     def end(self, _interrupted: bool) -> None:
-        DataLogManager.log("... DONE")
+        print("... DONE")

--- a/src/commands/drive/drivewaypoint.py
+++ b/src/commands/drive/drivewaypoint.py
@@ -7,7 +7,7 @@ from pykit.logger import Logger
 from wpimath.trajectory import TrapezoidProfile, TrapezoidProfileRadians
 from wpimath.controller import ProfiledPIDController, ProfiledPIDControllerRadians
 from wpimath.geometry import Pose2d
-from wpilib import DataLogManager, DriverStation
+from wpilib import DriverStation
 
 from robotstate import RobotState
 from subsystems.drive.drivesubsystem import DriveSubsystem
@@ -126,4 +126,4 @@ class DriveWaypoint(Command):
 
     def end(self, _interrupted: bool) -> None:
         # pylint: disable=W0212
-        DataLogManager.log("... DONE")
+        print("... DONE")

--- a/src/commands/resetdrive.py
+++ b/src/commands/resetdrive.py
@@ -1,4 +1,3 @@
-from wpilib import DataLogManager
 from commands2.command import Command
 from wpimath.geometry import Pose2d
 
@@ -15,14 +14,14 @@ class ResetDrive(Command):
         self.addRequirements(self.drive)
 
     def initialize(self) -> None:
-        DataLogManager.log(f"Command: {self.getName()}")
+        print(f"Command: {self.getName()}")
 
     def execute(self) -> None:
         self.drive.resetSwerveModules()
         RobotState.resetPose()
 
     def end(self, _interrupted: bool) -> None:
-        DataLogManager.log("... DONE")
+        print("... DONE")
 
     def isFinished(self) -> bool:
         return True

--- a/src/commands/resetgyro.py
+++ b/src/commands/resetgyro.py
@@ -1,4 +1,3 @@
-from wpilib import DataLogManager
 from commands2.command import Command
 from wpimath.geometry import Pose2d
 
@@ -15,13 +14,13 @@ class ResetGyro(Command):
         self.addRequirements(self.drive)
 
     def initialize(self) -> None:
-        DataLogManager.log(f"Command: {self.getName()}")
+        print(f"Command: {self.getName()}")
 
     def execute(self) -> None:
         RobotState.resetPose()
 
     def end(self, _interrupted: bool) -> None:
-        DataLogManager.log("... DONE")
+        print("... DONE")
 
     def isFinished(self) -> bool:
         return True

--- a/src/physics.py
+++ b/src/physics.py
@@ -10,7 +10,7 @@
 #
 
 from phoenix6.unmanaged import feed_enable
-from wpilib import DataLogManager, RobotController
+from wpilib import RobotController
 from wpimath.geometry import Pose2d, Rotation2d, Transform2d
 from pyfrc.physics.core import PhysicsInterface
 from robot import MentorBot
@@ -70,11 +70,11 @@ class PhysicsEngine:
         if not isinstance(driveSubsystem.frontLeftModule.io, SwerveModuleIOCTRE):
             # do not simulation
             self.doSim = False
-            DataLogManager.log("[Physics] WARNING: Not simulating")
+            print("[Physics] WARNING: Not simulating")
             return
 
         self.doSim = True
-        DataLogManager.log("[Physics] beginning simulation")
+        print("[Physics] beginning simulation")
 
         self.driveSim = SwerveDriveSim(driveSubsystem)
 

--- a/src/robotcontainer.py
+++ b/src/robotcontainer.py
@@ -80,7 +80,6 @@ class RobotContainer:
         # The robot's subsystems
         match kRobotMode:
             case RobotModes.REAL:
-                wpilib.DataLogManager.log("Starting REAL")
                 self.drive = DriveSubsystem(
                     DriveIOPigeon(),
                     (

--- a/src/robotstate.py
+++ b/src/robotstate.py
@@ -1,6 +1,6 @@
 from typing import Callable
 from pykit.logger import Logger
-from wpilib import DataLogManager, RobotBase
+from wpilib import RobotBase
 from wpimath.geometry import Pose2d, Rotation2d
 from wpimath.kinematics import ChassisSpeeds, SwerveDrive4Odometry, SwerveModulePosition
 
@@ -127,7 +127,7 @@ class RobotState:
             for consumer in cls.simResetPoseConsumers:
                 consumer(pose)
             return
-        DataLogManager.log("This is not supposed to happen")
+        print("This is not supposed to happen")
 
     @classmethod
     def registerSimPoseResetConsumer(cls, consumer: Callable[[Pose2d], None]) -> None:
@@ -137,7 +137,7 @@ class RobotState:
     def getSimPose(cls) -> Pose2d:
         if len(cls.simPoseRecieverConsumers) == 1:
             return cls.simPoseRecieverConsumers[0]()
-        DataLogManager.log("This is not supposed to happen")
+        print("This is not supposed to happen")
         return cls.getPose()
 
     @classmethod


### PR DESCRIPTION
PyKit now supports hijacking direct print statments to outputs, use them instead of DataLogManager for consistency when in a no-wpilog scenerio (sim)