### PR TITLE
HOTFIX: ID CONDENSING

### DIFF
--- a/src/subsystems/vision/visionio.py
+++ b/src/subsystems/vision/visionio.py
@@ -3,8 +3,7 @@ from enum import Enum
 from typing import List
 from pykit.autolog import autolog
 from wpimath.geometry import Pose3d, Transform3d
-from wpiutil.wpistruct import make_wpistruct
-from wpiutil.wpistruct import uint64
+from wpiutil.wpistruct import make_wpistruct, uint32
 
 
 class ObservationType(Enum):
@@ -21,7 +20,7 @@ class VisionSubsystemPoseObservation:
     pose: Pose3d = field(default_factory=Pose3d)
     ambiguity: float = 0
     tagCount: int = 0
-    tagsList: uint64 = uint64(0)
+    tagsList: uint32 = uint32(0)
     averageTagDistance: float = 0
     observationType: int = ObservationType.PHOTONVISION.value
 
@@ -34,7 +33,7 @@ class VisionSubsystemTurretedPoseObservation:
     fieldToTurret: Transform3d = field(default_factory=Transform3d)
     ambiguity: float = 0
     tagCount: int = 0
-    tagsList: uint64 = uint64(0)
+    tagsList: uint32 = uint32(0)
     averageTagDistance: float = 0
     observationType: int = ObservationType.PHOTONVISION.value
 

--- a/src/subsystems/vision/visioniophoton.py
+++ b/src/subsystems/vision/visioniophoton.py
@@ -50,9 +50,11 @@ class VisionSubsystemIOPhotonVision(VisionSubsystemIO):
                 tagIds.extend(result.multitagResult.fiducialIDsUsed)
 
                 idsCondensed = 0
+                # this is stored in a 32 bit unsigned integer, this is OK since only 32 tags exist on the field
                 for tagId in result.multitagResult.fiducialIDsUsed:
-                    idsCondensed *= 100
-                    idsCondensed += tagId
+                    idsCondensed |= (
+                        1 << tagId - 1
+                    )  # condense the tag IDs into a single integer using bitwise OR. This allows us to store up to 32 tag IDs in a single integer, which is more efficient than storing a list of integers.
 
                 if not self.isTurreted:
                     poseObservations.append(

--- a/src/subsystems/vision/visionsubsystem.py
+++ b/src/subsystems/vision/visionsubsystem.py
@@ -32,7 +32,7 @@ class VisionSubsystem(Subsystem):
         for _ in io:
             self.inputs.append(VisionSubsystemIO.VisionSubsystemIOInputs())
 
-    # pylint:disable-next=too-many-locals, too-many-statements
+    # pylint:disable-next=too-many-locals, too-many-statements, too-many-branches
     def periodic(self) -> None:
         LogTracer.resetOuter("VisionSubsystem")
         for idx, (i, inp) in enumerate(zip(self.io, self.inputs)):
@@ -99,9 +99,9 @@ class VisionSubsystem(Subsystem):
 
                 observedTags = []
                 tagsList = observation.tagsList
-                while tagsList > 0:
-                    observedTags.append(tagsList % 100)
-                    tagsList //= 100
+                for tagId in range(32):
+                    if tagsList & (1 << tagId - 1):
+                        observedTags.append(tagId)
 
                 self.consumer(
                     VisionObservation(
@@ -150,9 +150,10 @@ class VisionSubsystem(Subsystem):
                 # here you can also factor in per-camera weighting
                 observedTags = []
                 tagsList = observation.tagsList
-                while tagsList > 0:
-                    observedTags.append(tagsList % 100)
-                    tagsList //= 100
+                # extract tag list from bit masks
+                for tagId in range(32):
+                    if tagsList & (1 << tagId):
+                        observedTags.append(tagId)
 
                 self.turretedConsumer(
                     TurretedVisionObservation(


### PR DESCRIPTION
wpistruct doesn't allow for dynamically sized arrays, allocated 4 bytes for storage of ids to then parse out

max value is 9,223,372,036,854,775,807 meaning in current implementation a robot needs to see 10 total tags at once in a vision system to crash. A future fix will be implemented for a better method of condensing ids